### PR TITLE
Replace nshot with an enable/disable approach to support primary time observing

### DIFF
--- a/automator/automator.py
+++ b/automator/automator.py
@@ -349,7 +349,6 @@ class Automator(object):
             if redis_util.primary_sequence_end(self.redis_server, subarray):
                 log.info(f"""A primary sequence has ended for {subarray},
                 therefore not recording.""")
-                redis_util.disable_recording(self.redis_server, subarray)
             else:
                 log.info("subarray {} is ready for recording".format(subarray))
                 redis_util.enable_recording(self.redis_server, subarray)

--- a/automator/automator.py
+++ b/automator/automator.py
@@ -22,7 +22,7 @@ class Automator(object):
       
     The recording is more directly controlled by the coordinator.
     The automator instructs the coordinator when it can record by setting
-    an `enabled` key in redis.
+    a `rec_enabled:<array>` key in redis.
 
     Processing is done with slurm wrapping seticore and hpguppi_proc.
 

--- a/automator/automator.py
+++ b/automator/automator.py
@@ -62,7 +62,7 @@ class Automator(object):
         buffer_length (float): Maximum duration of recording (in seconds)
         for the maximum possible incoming data rate. 
         """
-        log.info('starting the automator. redis = {}'.format(redis_endpoint))
+        log.info(f"starting the automator. redis = {redis_endpoint}")
         redis_host, redis_port = redis_endpoint.split(':')
         self.redis_server = redis.StrictRedis(host=redis_host, 
                                               port=redis_port, 
@@ -116,11 +116,11 @@ class Automator(object):
         msg_data = msg['data'] 
         msg_components = msg_data.split(':')
         if len(msg_components) != 2:
-            log.warning("Unrecognised message: {}".format(msg_data))
+            log.warning(f"Unrecognised message: {msg_data}")
             return
 
         subarray_state, subarray_name = msg_components
-        log.info('subarray {} is now in state: {}'.format(subarray_name, subarray_state))
+        log.info(f"subarray {subarray_name} is now in state: {subarray_state}")
 
         if self.paused:
             log.info("Paused, taking no action")
@@ -142,7 +142,7 @@ class Automator(object):
         back later to see if we are ready to process.
         """
 
-        log.info('{} in tracking state'.format(subarray_name))
+        log.info(f"{subarray_name} in tracking state")
 
         # If a sequence of primary time observations has ended (ie, this current
         # track is not a primary time track), then process right away:
@@ -156,13 +156,13 @@ class Automator(object):
             # If this is the last recording before the buffers will be full, 
             # we may want to process in about `DWELL` + margin seconds.
             allocated_hosts = redis_util.allocated_hosts(self.redis_server, subarray_name)
-            log.info("allocated hosts for {}: {}".format(subarray_name, allocated_hosts))
+            log.info(f"allocated hosts for {subarray_name}: {allocated_hosts}")
             dwell = self.retrieve_dwell(allocated_hosts, DEFAULT_DWELL)
-            log.info("dwell: {}".format(dwell))
+            log.info(f"dwell: {dwell}")
             duration = dwell + self.margin
 
             # Start a timer to check for processing
-            log.info('starting tracking timer for {} seconds'.format(duration))
+            log.info(f"starting tracking timer for {duration} seconds")
             t = threading.Timer(duration, lambda: self.maybe_start_processing())
             t.start()
             self.timers[subarray_name] = t
@@ -233,14 +233,13 @@ class Automator(object):
             return False
 
         if self.processing.intersection(hosts):
-            log.error("currently processing {} so cannot double-process {}".format(
-                self.processing, hosts))
+            log.error(f"currently processing {self.processing} so cannot double-process {hosts}"
             return False
         self.processing = self.processing.union(hosts)
 
         timestamped_dir = redis_util.timestamped_dir_from_filename(input_dir)
         if timestamped_dir is None:
-            self.pause("unexpected directory name: {}".format(input_dir))
+            self.pause(f"unexpected directory name: {input_dir}")
             return False
         
         # Run seticore
@@ -248,10 +247,9 @@ class Automator(object):
         result_seticore = run_seticore(sorted(hosts), BFRDIR, input_dir, timestamped_dir, partition)
         if result_seticore > 1:
             if result_seticore > 128:
-                self.pause("seticore killed with signal {}".format(result_seticore - 128))
+                self.pause(f"seticore killed with signal {result_seticore - 128}")
             else:
-                self.pause("the seticore slurm job failed with code {}".format(
-                    result_seticore))
+                self.pause(f"the seticore slurm job failed with code {result_seticore}")
             self.alert_seticore_error()
             return False
         self.alert(f"seticore completed with code {result_seticore}. "
@@ -324,8 +322,7 @@ class Automator(object):
                 return True
             time.sleep(2)
 
-        self.pause("failed to delete buf0 on {} hosts: {}".format(
-            len(hosts), " ".join(sorted(hosts))))
+        self.pause(f"failed to delete buf0 on {len(hosts)} hosts: {" ".join(sorted(hosts))}")
         return False
     
             
@@ -338,8 +335,7 @@ class Automator(object):
         """
         broken = redis_util.broken_daqs(self.redis_server)
         if broken:
-            self.pause("{} daqs appear to be broken: {}".format(
-                len(broken), " ".join(broken)))
+            self.pause(f"{len(broken)} daqs appear to be broken: {" ".join(broken)}")
             return
         subarrays = redis_util.suggest_recording(self.redis_server,
                                                  processing=self.processing)
@@ -350,7 +346,7 @@ class Automator(object):
                 log.info(f"""A primary sequence has ended for {subarray},
                 therefore not recording.""")
             else:
-                log.info("subarray {} is ready for recording".format(subarray))
+                log.info(f"subarray {subarray} is ready for recording")
                 redis_util.enable_recording(self.redis_server, subarray)
         
         
@@ -371,21 +367,21 @@ class Automator(object):
         dwell = default_dwell
         dwell_values = []
         for host in host_list:
-            host_key = '{}://{}/0/status'.format(self.hpgdomain, host)
+            host_key = f"{self.hpgdomain}://{host}/0/status"
             host_status = self.redis_server.hgetall(host_key)
             if len(host_status) > 0:
                 if 'DWELL' in host_status:
                     dwell_values.append(float(host_status['DWELL']))
                 else:
-                    log.warning('Cannot retrieve DWELL for {}'.format(host))
+                    log.warning(f"Cannot retrieve DWELL for {host}")
             else:
-                log.warning('Cannot access {}'.format(host))
+                log.warning(f"Cannot access {host}")
         if len(dwell_values) > 0:
             dwell = self.mode_1d(dwell_values)
             if len(np.unique(dwell_values)) > 1:
                 log.warning("DWELL disagreement")    
         else:
-            log.warning("Could not retrieve DWELL. Using {} sec by default.".format(default_dwell))
+            log.warning(f"Could not retrieve DWELL. Using {default_dwell} sec by default.")
         return dwell
 
     

--- a/automator/automator.py
+++ b/automator/automator.py
@@ -22,7 +22,7 @@ class Automator(object):
       
     The recording is more directly controlled by the coordinator.
     The automator instructs the coordinator when it can record by setting
-    a `rec_enabled:<array>` key in redis.
+    a `rec_enabled:<array>` key to 1 in redis.
 
     Processing is done with slurm wrapping seticore and hpguppi_proc.
 
@@ -34,8 +34,9 @@ class Automator(object):
     could still be intensively processing a different subarray.
 
     2. When the automator isn't doing any processing on a set of machines that
-    the coordinator has allocated to a subarray, it uses the redis key: 
-    `rec_enabled:<subarray name>` to tell the coordinator it can record on them.
+    the coordinator has allocated to a subarray, it sets the Redis key:
+    `rec_enabled:<subarray name>` to 1 to tell the coordinator it can record
+    on them.
 
     3. When the automator notices the coordinator is done recording, it runs
     processing. When processing finishes, the automator has deleted the raw files.

--- a/automator/automator.py
+++ b/automator/automator.py
@@ -335,8 +335,8 @@ class Automator(object):
             # If a primary sequence has ended, we don't want to record
             # the next track.
             if redis_util.primary_sequence_end(self.redis_server, subarray):
-                log.info(f"""A primary sequence has ended for {subarray},
-                therefore not recording.""")
+                log.info(f"A primary sequence has ended for {subarray},"
+                " therefore not recording.")
             else:
                 log.info(f"subarray {subarray} is ready for recording")
                 redis_util.enable_recording(self.redis_server, subarray)

--- a/automator/cli.py
+++ b/automator/cli.py
@@ -32,14 +32,6 @@ def cli(args = sys.argv[0]):
                         type = float,
                         default = 300.0, 
                         help = 'Max recording length at max data rate (sec)')
-    parser.add_argument('--nshot_chan',
-                        type = str,
-                        default = 'coordinator:trigger_mode', 
-                        help = 'Redis channel for changing nshot')
-    parser.add_argument('--nshot_msg',
-                        type = str,
-                        default = 'coordinator:trigger_mode:{}:nshot:{}', 
-                        help = 'Format of message for changing nshot')
     parser.add_argument('--partition',
                         type = str,
                         default = 'scratch', 
@@ -53,12 +45,10 @@ def cli(args = sys.argv[0]):
          margin = args.margin, 
          hpgdomain = args.hpgdomain, 
          buffer_length = args.buffer_length, 
-         nshot_chan = args.nshot_chan, 
-         nshot_msg = args.nshot_msg,
          partition = args.partition)
 
 def main(redis_endpoint, redis_channel, margin, hpgdomain, 
-    buffer_length, nshot_chan, nshot_msg, partition):
+    buffer_length, partition):
     """Starts the automator.
   
     Args: 
@@ -72,9 +62,6 @@ def main(redis_endpoint, redis_channel, margin, hpgdomain,
         in question. 
         buffer_length (float): Maximum duration of recording (in seconds)
         for the maximum possible incoming data rate. 
-        nshot_chan (str): The Redis channel for resetting nshot.
-        nshot_msg (str): The base form of the Redis message for resetting
-        nshot. For example, `coordinator:trigger_mode:<subarray_name>:nshot:<n>`
         partition (str): Name of destination partition for seticore output.
 
     Returns:
@@ -87,8 +74,6 @@ def main(redis_endpoint, redis_channel, margin, hpgdomain,
                           margin, 
                           hpgdomain, 
                           buffer_length, 
-                          nshot_chan, 
-                          nshot_msg,
                           partition)
     Automaton.start()
 

--- a/automator/redis_util.py
+++ b/automator/redis_util.py
@@ -238,8 +238,8 @@ def ready_to_record(r):
     answer = set()
     subarrays = coordinator_subarrays(r)
     for subarray in subarrays:
-        nshot = get_nshot(r, subarray)
-        if nshot > 0:
+        # If recording enabled, union
+        if redis_util.is_rec_enabled(r, subarray):
             answer = answer.union(allocated_hosts(r, subarray))
     return sorted(answer)
 

--- a/automator/redis_util.py
+++ b/automator/redis_util.py
@@ -87,7 +87,7 @@ def enable_recording(r, subarray_name):
     rec_setting = is_rec_enabled(r, subarray_name)
     log.info('rec_setting {}, setting to 1'.format(rec_setting))
     rec_setting_key = 'rec_enabled:{}'.format(subarray_name)
-    self.r.set(rec_setting_key, 1) 
+    r.set(rec_setting_key, 1) 
 
 def disable_recording(r, subarray_name):
     """Prevent recording from proceeding for new tracks for 
@@ -96,7 +96,7 @@ def disable_recording(r, subarray_name):
     rec_setting = is_rec_enabled(r, subarray_name)
     log.info('rec_setting {}, setting to 0'.format(rec_setting))
     rec_setting_key = 'rec_enabled:{}'.format(subarray_name)
-    self.r.set(rec_setting_key, 0) 
+    r.set(rec_setting_key, 0) 
 
 def get_bluse_dwell(r, subarray_name):
     """Get specified dwell for BLUSE primary time observing.

--- a/automator/redis_util.py
+++ b/automator/redis_util.py
@@ -129,8 +129,8 @@ def channel_list(hpgdomain, instances):
     return channel_list
 
 def is_primary_time(r, subarray_name):
-    """Check if the current observation ID is for BLUSE primary
-    time. 
+    """Check if the current (or most recent) observation ID is for BLUSE
+    primary time.
     """
     subarray = 'subarray_{}'.format(subarray_name[-1])
     p_id_key = '{}_script_proposal_id'.format(subarray)
@@ -173,6 +173,16 @@ def primary_time_in_progress(r):
             log.info('Not processing: nshot is {}'.format(nshot))
             return True
     return False
+
+
+def primary_sequence_end(r, subarray):
+    """If the previously recorded track was a primary time track, and the
+    current track is not a primary time track, return True.
+    """
+    if get_last_rec_bluse(r, subarray) and is_primary_time(r, subarray):
+        return True
+    return False
+
 
 def all_hosts(r):
     return sorted(key.split("//")[-1].split("/")[0]

--- a/automator/redis_util.py
+++ b/automator/redis_util.py
@@ -130,7 +130,7 @@ def get_last_rec_bluse(r, subarray_name):
     """Return True if last recording was made under the BLUSE
     proposal ID (thus primary time). 
     """
-    key = f"{subarray_name}:primary_time"
+    key = f"{subarray_name}:last_rec_primary_t"
     val = r.get(key)
     try:
         val = int(val)
@@ -142,7 +142,7 @@ def set_last_rec_bluse(r, subarray_name, value):
     """Set the value (bool) of the last recording proposal
     ID flag (True if BLUSE ID, False if not).
     """ 
-    key = f"{subarray_name}:primary_time"
+    key = f"{subarray_name}:last_rec_primary_t"
     log.info(f"setting primary time status for {subarray_name}: {value}")
     r.set(key, value)
 

--- a/automator/redis_util.py
+++ b/automator/redis_util.py
@@ -151,7 +151,7 @@ def primary_sequence_end(r, subarray):
     """If the previously recorded track was a primary time track, and the
     current track is not a primary time track, return True.
     """
-    if get_last_rec_bluse(r, subarray) and is_primary_time(r, subarray):
+    if get_last_rec_bluse(r, subarray) and not is_primary_time(r, subarray):
         return True
     return False
 

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -350,7 +350,7 @@ class Coordinator(object):
             redis_util.set_last_rec_bluse(self.red, product_id, 1)
 
         else:
-            # Set flag: current recording is BLUSE primary time.
+            # Set flag: current recording is not BLUSE primary time.
             redis_util.set_last_rec_bluse(self.red, product_id, 0)
             # Disable recording; automator will re-enable.
             redis_util.disable_recording(self.red, product_id)

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -107,8 +107,6 @@ class Coordinator(object):
         """
         # Configure coordinator
         self.alert('starting up')
-        # Reset primary time flag:
-        redis_util.set_last_rec_bluse(self.red, product_id, 0)
         try:
             self.hashpipe_instances, self.streams_per_instance = self.config(self.cfg_file)
             log.info('Configured from {}'.format(self.cfg_file))
@@ -201,6 +199,8 @@ class Coordinator(object):
             )
         log.info('New subarray built: {}'.format(product_id))
         tracking = 0 # Initialise tracking state to 0
+        # Reset primary time flag:
+        redis_util.set_last_rec_bluse(self.red, product_id, 0)
         # Initialise cal_solutions timestamp to 0 to ensure the most recent
         # cal solutions are recorded. Note using Redis here so that the value persists
         # even if the coordinator is restarted in the middle of an observation. 

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -195,7 +195,8 @@ class Coordinator(object):
             f"{product_id}: Coordinator configuring DAQs."
             )
         log.info(f"New subarray built: {product_id}")
-        tracking = 0 # Initialise tracking state to 0
+        # Initialise tracking state to 0
+        self.red.set(f"coordinator:tracking:{product_id}", '0')
         # Reset primary time flag:
         redis_util.set_last_rec_bluse(self.red, product_id, 0)
         # Initialise cal_solutions timestamp to 0 to ensure the most recent

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -23,9 +23,6 @@ TARGETS_CHANNEL = 'target-selector:new-pointing'
 
 # Standard DWELL time to fill the buffers:
 DEFAULT_DWELL = 290
-# Primary time dwell:
-# ToDo: Make these CLI args or Redis keys
-PRIMARY_TIME_DWELL = 30
 
 # Type of stream
 STREAM_TYPE = 'cbf.antenna_channelised_voltage'
@@ -342,8 +339,6 @@ class Coordinator(object):
                 # it could be part of a sequence of primary time tracks that
                 # we only want to process at the end.
 
-                # Set DWELL to the desired primary time DWELL:
-                redis_util.reset_dwell(self.red, allocated_hosts, PRIMARY_TIME_DWELL)
                 # Set flag: current recording is BLUSE primary time.
                 redis_util.set_last_rec_bluse(self.red, product_id, 1)
 

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -491,7 +491,7 @@ class Coordinator(object):
         self.alert(f"Instructed recording for {product_id} to {datadir}")
 
         if redis_util.is_primary_time(self.red, product_id):
-            self.alert("Primary time observation for {product_id")
+            self.alert(f"Primary time observation for {product_id}")
         
     def tracking_stop(self, product_id):
         """If the subarray stops tracking a source (more specifically, if the incoming 


### PR DESCRIPTION
Instead of controlling observing by setting `nshot` to 0 or 1, the automator enables and disables recording via a dedicated Redis key. These changes also support a "primary time mode". 

When we are doing our own primary time observing, we may want to record a sequence of short pointings that together add up to the full 5 minute recording time. In this scenario, we don't want to trigger processing by seticore until the sequence is complete (otherwise there would need to be a gap between our primary time pointings). 

The automator and coordinator automatically detect when our primary time project ID comes up (indicating that the current pointing is one of our own primary time pointings). When this happens, processing by seticore is prevented until a non-primary time pointing comes up. In addition, once processing by seticore is completed, the automator pauses and the data in the NVMe modules is not deleted (as we may need to keep it). 

Doing it this way means the automator and coordinator don't need to be told how many primary time pointings will be in a sequence (or how long they will be). It does mean that the author of the primary time schedule block needs to make sure that the sequence of pointings they select does not exceed `DWELL` (currently 290 seconds). 