### PR TITLE
Write .h5 files every 10th run to save space. Some small bugfixes.

### DIFF
--- a/automator/automator.py
+++ b/automator/automator.py
@@ -225,7 +225,7 @@ class Automator(object):
             return False
 
         if self.processing.intersection(hosts):
-            log.error(f"currently processing {self.processing} so cannot double-process {hosts}"
+            log.error(f"currently processing {self.processing} so cannot double-process {hosts}")
             return False
         self.processing = self.processing.union(hosts)
 
@@ -236,7 +236,8 @@ class Automator(object):
         
         # Run seticore
         self.alert("running seticore...")
-        result_seticore = run_seticore(sorted(hosts), BFRDIR, input_dir, timestamped_dir, partition)
+        result_seticore = run_seticore(sorted(hosts), BFRDIR, input_dir,
+                                timestamped_dir, partition, self.redis_server)
         if result_seticore > 1:
             if result_seticore > 128:
                 self.pause(f"seticore killed with signal {result_seticore - 128}")
@@ -314,7 +315,7 @@ class Automator(object):
                 return True
             time.sleep(2)
 
-        self.pause(f"failed to delete buf0 on {len(hosts)} hosts: {" ".join(sorted(hosts))}")
+        self.pause(f"failed to delete buf0 on {len(hosts)} hosts: " + " ".join(sorted(hosts)))
         return False
     
             
@@ -327,7 +328,7 @@ class Automator(object):
         """
         broken = redis_util.broken_daqs(self.redis_server)
         if broken:
-            self.pause(f"{len(broken)} daqs appear to be broken: {" ".join(broken)}")
+            self.pause(f"{len(broken)} daqs appear to be broken: " + " ".join(broken))
             return
         subarrays = redis_util.suggest_recording(self.redis_server,
                                                  processing=self.processing)

--- a/automator/proc_seticore.py
+++ b/automator/proc_seticore.py
@@ -1,11 +1,8 @@
-import redis
-import time
-import os
 import subprocess
 
 from .logger import log
 
-def run_seticore(hosts, bfrdir, inputdir, timestamped_dir, partition):
+def run_seticore(hosts, bfrdir, inputdir, timestamped_dir, partition, r):
     """Processes the incoming data using seticore.
 
     Args:
@@ -17,19 +14,18 @@ def run_seticore(hosts, bfrdir, inputdir, timestamped_dir, partition):
         inputdir (str): Directory containing raw file input
         timestamped_dir (str): directory component starting with a timestamp
         partition (str): partition component of output directory.
+        r (obj): redis server.
 
     Returns:
         None
     """
+
     # Create output directories:
     outputdir = f"/{partition}/data/{timestamped_dir}/seticore_search"
-    h5dir = f"/{partition}/data/{timestamped_dir}/seticore_beamformer"
     log.info("Creating output directories...") 
-    log.info(f"\nsearch: {outputdir}\nbeamformer: {h5dir}")
+    log.info(f"Search: {outputdir}")
     for host in hosts:
         cmd = ["ssh", host, "mkdir", "-p", "-m", "1777", outputdir]
-        subprocess.run(cmd)
-        cmd = ["ssh", host, "mkdir", "-p", "-m", "1777", h5dir]
         subprocess.run(cmd)
 
     # Build slurm command:
@@ -37,11 +33,26 @@ def run_seticore(hosts, bfrdir, inputdir, timestamped_dir, partition):
                         "--input", inputdir,
                         "--output", outputdir, 
                         "--snr", "6",
-                        "--h5_dir", h5dir, 
                         "--num_bands", "16",
                         "--fine_channels", "8388608",
                         "--telescope_id", "64",
                         "--recipe_dir", bfrdir]
+
+    # Check number of times a processing sequence has been run and write .h5
+    # files for each beamformer output
+    n = redis_util.get_n_proc(r)
+    if n%10 == 0:
+        # create directory for h5 files
+        h5dir = f"/{partition}/data/{timestamped_dir}/seticore_beamformer"
+        log.info("Creating beamformer output directory...")
+        log.info(f"Beamformer: {h5dir}")
+        for host in hosts:
+            cmd = ["ssh", host, "mkdir", "-p", "-m", "1777", h5dir]
+            subprocess.run(cmd)
+        # add --h5_dir arg to seticore command
+        seticore_command.extend(["--h5_dir", h5dir])
+    redis_util.increment_n_proc(r)
+
     err = "/home/obs/seticore_slurm/seticore_%N.err"
     out = "/home/obs/seticore_slurm/seticore_%N.out"
     cmd = (["srun", "--open-mode=append", "-e", err, "-o", out, "-w"] +

--- a/automator/redis_util.py
+++ b/automator/redis_util.py
@@ -155,6 +155,20 @@ def primary_sequence_end(r, subarray):
         return True
     return False
 
+def get_n_proc(r):
+    """Retrieve the absolute number of times processing has been run.
+    """
+    n_proc = r.get("automator:n_proc")
+    if n_proc is None:
+        r.set("automator:n_proc", 0)
+        return 0
+    return int(n_proc)
+
+def increment_n_proc(r):
+    """Add 1 to the number of times processing has been run.
+    """
+    n_proc = get_n_proc(r)
+    r.set("automator:n_proc", n_proc + 1)
 
 def all_hosts(r):
     return sorted(key.split("//")[-1].split("/")[0]
@@ -439,7 +453,7 @@ def set_group_key(r, group_name, gateway_domain, key, value):
     # Message to set key:
     message = f"{key}={value}"
     r.publish(group_channel, message)
-    log.info(f"Set {key} to {value} for {gateway_domain} instances in group {group_name}"
+    log.info(f"Set {key} to {value} for {gateway_domain} instances in group {group_name}")
 
 def hpguppi_procstat(r):
     """Returns a map from hpguppi states to a list of hosts in them.


### PR DESCRIPTION
This is for issue #9 to reduce the total volume of the saved diagnostic beamformer output. We should save the beamformer outputs only every 10th time that we process. 