### PR TITLE
Prevent race condition when tracking starts

### DIFF
--- a/automator/automator.py
+++ b/automator/automator.py
@@ -198,6 +198,7 @@ class Automator(object):
         input_dir, hosts = list(dirmap.items())[0]
         if not self.process(input_dir, hosts, self.partition):
             return
+        self.maybe_start_recording()
         self.maybe_start_processing()
 
 

--- a/automator/redis_util.py
+++ b/automator/redis_util.py
@@ -8,7 +8,7 @@ import re
 import redis
 import sys
 import time
-import numpy
+import numpy as np
 
 from automator.logger import log
 
@@ -226,7 +226,7 @@ def ready_to_record(r):
     subarrays = coordinator_subarrays(r)
     for subarray in subarrays:
         # If recording enabled
-        if redis_util.is_rec_enabled(r, subarray):
+        if is_rec_enabled(r, subarray):
             answer = answer.union(allocated_hosts(r, subarray))
     return sorted(answer)
 

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -662,9 +662,9 @@ class Coordinator(object):
             self.pub_gateway_msg(self.red, subarray_group, 'RA_STR', ra_str, log, False)
         # Azimuth and elevation (in degrees):
         elif 'azim' in description:
-            self.pub_gateway_msg(self.red, subarray_group, 'AZ', value, log, False)
+            self.pub_gateway_msg(self.red, subarray_group, 'AZ', value, None, False)
         elif 'elev' in description:
-            self.pub_gateway_msg(self.red, subarray_group, 'EL', value, log, False)
+            self.pub_gateway_msg(self.red, subarray_group, 'EL', value, None, False)
 
     def offset_ut(self, msg_type, value):
         """Publish UT1_UTC, the difference (in seconds) between UT1 and UTC
@@ -928,7 +928,8 @@ class Coordinator(object):
         if write:
             red_server.hset(chan_name, msg_name, msg_val)
             logger.info(f"Wrote {msg} for channel {chan_name} to Redis")
-        logger.info(f"Published {msg} to channel {chan_name}")
+        if logger is not None:
+            logger.info(f"Published {msg} to channel {chan_name}")
 
     def parse_redis_msg(self, message):
         """Process incoming Redis messages from the various pub/sub channels. 

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -1076,9 +1076,7 @@ class Coordinator(object):
         """
         sensor_key = self.stream_sensor_name(product_id,
             'antenna_channelised_voltage_centre_frequency')
-        log.info(sensor_key)
         centre_freq = self.red.get(sensor_key)
-        log.info(centre_freq)
         centre_freq = float(centre_freq)/1e6
         centre_freq = '{0:.17g}'.format(centre_freq)
         return centre_freq


### PR DESCRIPTION
There's a race condition when the `tracking` alert is received by the automator and coordinator. 

The coordinator checks if recording is enabled. If it is, it disables recording and instructs the DAQs to record. There is a short gap of a few hundred milliseconds before the DAQs respond to the Redis messages and start recording. 

The automator runs `maybe_start_recording()` on every incoming alerts message. That means it also checks if recording should be enabled when the `tracking` alert is received. In at least one occasion, this check was performed in the gap between when the coordinator disabled recording and when recording started (example logs below). The automator, seeing that the DAQs were not currently recording, and that `rec_enabled` was 0, re-enabled recording in this gap. 

The result was that no processing took place when the timer ran out, since the automator saw that recording was still enabled and therefore did not process. In addition, we later on recorded another track, probably completely filling the NVMe drives and causing the DAQs to have issues. 

To fix this, I think we should not call `maybe_start_recording()` when a `tracking` message is received. I also think we should call `maybe_start_recording()` after processing is complete, to re-enable recording for the next track right away. 

Example logs:
```
coordinator:
[2023-05-11 01:18:47,529 - INFO - redis_util.py:83] rec_setting 1, setting to 0
...
[2023-05-11 01:18:47,697 - INFO - coordinator.py:931] Published PKTSTART=46353408 to channel bluse:array_1///set
...
[2023-05-11 02:20:28,966 - INFO - redis_util.py:83] rec_setting 1, setting to 0

automator:
[2023-05-11 01:16:23,828 - INFO - redis_util.py:75] rec_setting 0, setting to 1
...
[2023-05-11 01:18:47,481 - INFO - automator.py:124] subarray array_1 is now in state: tracking
...
[2023-05-11 01:18:47,640 - INFO - redis_util.py:75] rec_setting 0, setting to 1
...
[2023-05-11 02:20:18,675 - INFO - automator.py:124] subarray array_1 is now in state: tracking
```