### PR TITLE
Improved handling of small subarrays. 

### DIFF
--- a/coordinator/proc_util.py
+++ b/coordinator/proc_util.py
@@ -2,6 +2,17 @@
 import re
 import os
 import shutil
+import numpy as np
+
+def output_summary(codes):
+    """Summarise output error codes.
+    """
+    summary = "codes "
+    if codes:
+        codes, counts = np.unique(codes, return_counts=True)
+        for code, count in zip(codes, counts):
+            summary = summary + f"`{code}: {count}` "
+    return summary
 
 def get_items(r, name, type):
     """Return the set of items of <type> from Redis.

--- a/coordinator/redis_util.py
+++ b/coordinator/redis_util.py
@@ -146,8 +146,7 @@ def channel_list(hpgdomain, instances):
     """Build a list of Hashpipe-Redis Gateway channels from a list
        of instance names (of format: host/instance)
     """
-    channel_list = [hpgdomain + '://' + instance + '/set' for instance in instances]
-    return channel_list
+    return [f"{hpgdomain}://{instance}/set" for instance in instances]
 
 def is_primary_time(r, subarray_name):
     """Check if the current (or most recent) observation ID is for BLUSE

--- a/coordinator/redis_util.py
+++ b/coordinator/redis_util.py
@@ -142,6 +142,13 @@ def reset_dwell(r, instances, dwell):
     for i in range(len(chan_list)):
         r.publish(chan_list[i], f"DWELL={dwell}")
 
+def channel_list(hpgdomain, instances):
+    """Build a list of Hashpipe-Redis Gateway channels from a list
+       of instance names (of format: host/instance)
+    """
+    channel_list = [hpgdomain + '://' + instance + '/set' for instance in instances]
+    return channel_list
+
 def is_primary_time(r, subarray_name):
     """Check if the current (or most recent) observation ID is for BLUSE
     primary time.

--- a/coordinator/states.py
+++ b/coordinator/states.py
@@ -91,8 +91,10 @@ class Subscribed(State):
         # Attempt to claim the required number of instances from those that
         # are free:
         n_requested = sub_util.num_requested(self.r, self.array)
+        free_instances = redis_util.sort_instances(list(data["free"]))
         while len(data["free"]) > 0 and len(data["subscribed"]) < n_requested:
-            data["subscribed"].add(data["free"].pop())
+            data["free"].remove(free_instances[0])
+            data["subscribed"].add(free_instances.pop(0))
         if len(data["subscribed"]) < n_requested:
             n_subs = len(data["subscribed"])
             message = f":warning: `{self.array}` {n_subs}/{n_requested} available."

--- a/coordinator/states.py
+++ b/coordinator/states.py
@@ -143,7 +143,7 @@ class Record(State):
 
         subscribed = data["subscribed"]
         ready = data["ready"]
-        if subscribed == subscribed.intersection(ready):
+        if subscribed.issubset(ready):
             result = rec.record(self.r, self.array, list(ready))
             if result:
                 # update data:

--- a/coordinator/states.py
+++ b/coordinator/states.py
@@ -231,9 +231,10 @@ class Process(State):
                 # If all (or whatever preferred percentage) is completed,
                 # continue to the next state:
                 if not data["processing"]:
+                    codes = proc_util.output_summary(self.returncodes)
                     if max(self.returncodes) < 1:
                         redis_util.alert(self.r,
-                            f":white_check_mark: `{self.array}` complete, code 0",
+                            f":white_check_mark: `{self.array}` complete: {codes}",
                             "coordinator")
                         proc_util.increment_n_proc(self.r)
                         self.returncodes = []
@@ -241,12 +242,15 @@ class Process(State):
                     # Check and clear the returncodes:
                     elif max(self.returncodes) < 2:
                         redis_util.alert(self.r,
-                            f":heavy_check_mark: `{self.array}` complete, codes: `{self.returncodes}`",
+                            f":heavy_check_mark: `{self.array}` complete: {codes}",
                             "coordinator")
                         proc_util.increment_n_proc(self.r)
                         self.returncodes = []
                         return Ready(self.array, self.r)
                     else:
+                        redis_util.alert(self.r,
+                            f":warning: `{self.array}`: {codes}",
+                            "coordinator")
                         return Error(self.array, self.r)
             else:
                 log.warning(f"Unrecognised instance: {instance}")

--- a/coordinator/states.py
+++ b/coordinator/states.py
@@ -141,7 +141,7 @@ class Record(State):
 
         subscribed = data["subscribed"]
         ready = data["ready"]
-        if ready == subscribed.intersection(ready):
+        if subscribed == subscribed.intersection(ready):
             result = rec.record(self.r, self.array, list(ready))
             if result:
                 # update data:


### PR DESCRIPTION
- When initiating recording, ensure that all the instances that are subscribed, are also ready. `subscribed` should be a subset of `ready` (it is possible in some cases that only a subset of the available `ready` instances are subscribed, e.g. in the case of small subarrays, and so recording should proceed so long as all `subscribed` instances are also `ready`, not the other way around). 

- Pre-sort instances in case the active subarray is an unusually small one and is only using a subset of the available instances (we need to subscribe to instances in sorted physical order, otherwise packet loss could occur for other MeerKAT users). 

- Report a summary of error codes rather than simply printing out the full list. 